### PR TITLE
Correct Mongo database setup directory reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Database setup guide
 
-Starting from the `expressServer` directory, setup and run the Mongo database.
+Starting from the `repository root` directory, setup and run the Mongo database.
 
 ### Start the MongoDB Database
 


### PR DESCRIPTION
Update the README to clarify that the Mongo database setup should start from the repository root directory instead of the expressServer directory.